### PR TITLE
use Seq2C libraries for Stat::Basic dependency

### DIFF
--- a/bam2reads.pl
+++ b/bam2reads.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 
 use strict;

--- a/cov2lr.pl
+++ b/cov2lr.pl
@@ -3,6 +3,9 @@
 # Normalize the coverage from targeted sequencing to CNV log2 ratio.  The algorithm assumes the medium 
 # is diploid, thus not suitable for homogeneous samples (e.g. parent-child).
 
+use FindBin;
+use lib "$FindBin::RealBin/libraries/";
+
 use Stat::Basic;
 use Getopt::Std;
 use strict;

--- a/lr2gene.pl
+++ b/lr2gene.pl
@@ -3,6 +3,9 @@
 # Normalize the coverage from targeted sequencing to CNV log2 ratio.  The algorithm assumes the medium 
 # is diploid, thus not suitable for homogeneous samples (e.g. parent-child).
 
+use FindBin;
+use lib "$FindBin::RealBin/libraries/";
+
 use Stat::Basic;
 use Statistics::TTest;
 use Getopt::Std;

--- a/testrand.pl
+++ b/testrand.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 # Create matrix consists needed number of lines containg 5 random elements in each line. Sum of elements in each line
 # will be the requested.
 use Getopt::Std;


### PR DESCRIPTION
Stat::Basic is a custom dependency inside `libraries` not available in CPAN.
This restores the previous behavior of getting it from the base install
directory.

Also swaps a couple of perl header calls to consistently use /usr/bin/env